### PR TITLE
Making it possible to make unique rides local or remote

### DIFF
--- a/worlds/openrct2/Options.py
+++ b/worlds/openrct2/Options.py
@@ -711,6 +711,15 @@ class RequiredUniqueRides(Range):
     range_end = 10
     default = 5
 
+class LocalityOfUniqueRides(Choice):
+    """Whether the unique rides should be local, remote, or anywhere."""
+    display_name = "Placement of Unique Rides"
+    option_off = 0
+    option_local = 1
+    option_remote = 2
+    default = 0
+
+
 class ParkRatingObjective(Range):
     """If enabled, choose the minimum park rating needed to beat the scenario."""
     display_name = "Park Rating Objective"
@@ -808,6 +817,7 @@ openrct2_option_groups = [
         RollerCoasterIntensity,
         RollerCoasterNausea,
         RequiredUniqueRides,
+        LocalityOfUniqueRides,
         ParkRatingObjective,
         PayOffLoan,
         MonopolyMode
@@ -900,6 +910,7 @@ class openRCT2Options(PerGameCommonOptions):
     roller_coaster_intensity: RollerCoasterIntensity
     roller_coaster_nausea: RollerCoasterNausea
     required_unique_rides: RequiredUniqueRides
+    unique_rides_placement: LocalityOfUniqueRides
     # include_park_rating_objective: Include_Park_Rating_Objective
     park_rating_objective: ParkRatingObjective
     pay_off_loan: PayOffLoan

--- a/worlds/openrct2/__init__.py
+++ b/worlds/openrct2/__init__.py
@@ -510,6 +510,13 @@ class OpenRCT2World(World):
             add_rule(self.multiworld.get_region("Victory", self.player).entrances[0],
                      lambda state, selected_prereq=ride: state.has(selected_prereq, self.player))
 
+        if self.options.unique_rides_placement.value != 0:
+            if self.options.unique_rides_placement.value == 1:
+                self.options.local_items.value.update(self.unique_rides)
+            elif self.options.unique_rides_placement.value == 2:
+                self.options.non_local_items.value.update(self.unique_rides)
+
+
     def generate_basic(self) -> None:
         # place "Victory" at the end of the unlock tree and set collection as win condition
         self.multiworld.get_location("Victory", self.player).place_locked_item(

--- a/worlds/openrct2/__init__.py
+++ b/worlds/openrct2/__init__.py
@@ -510,11 +510,10 @@ class OpenRCT2World(World):
             add_rule(self.multiworld.get_region("Victory", self.player).entrances[0],
                      lambda state, selected_prereq=ride: state.has(selected_prereq, self.player))
 
-        if self.options.unique_rides_placement.value != 0:
-            if self.options.unique_rides_placement.value == 1:
-                self.options.local_items.value.update(self.unique_rides)
-            elif self.options.unique_rides_placement.value == 2:
-                self.options.non_local_items.value.update(self.unique_rides)
+        if self.options.unique_rides_placement.value == 1:
+            self.options.local_items.value.update(self.unique_rides)
+        elif self.options.unique_rides_placement.value == 2:
+            self.options.non_local_items.value.update(self.unique_rides)
 
 
     def generate_basic(self) -> None:


### PR DESCRIPTION
Simple change to enable making the unique rides either local or remote.  According to the pinned post by Phar, local/non-local rules get run two steps after `set_rules`, so this should be safe to add where the unique rides get created.  