### PR TITLE
Removing the option to specify where in the multiworld unique rides g…

### DIFF
--- a/worlds/openrct2/Options.py
+++ b/worlds/openrct2/Options.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from Options import DefaultOnToggle, Toggle, Range, Choice, PerGameCommonOptions, OptionGroup
+from Options import DefaultOnToggle, Toggle, Range, Choice, PerGameCommonOptions, OptionGroup, Visibility as OptionVisibility
 from dataclasses import dataclass
 
 class Scenario(IntEnum):
@@ -712,13 +712,13 @@ class RequiredUniqueRides(Range):
     default = 5
 
 class LocalityOfUniqueRides(Choice):
-    """Whether the unique rides should be local, remote, or anywhere."""
+    """No-op; still here to prevent old YAMLs from breaking"""
     display_name = "Placement of Unique Rides"
     option_off = 0
     option_local = 1
     option_remote = 2
     default = 0
-
+    visibility = OptionVisibility.none
 
 class ParkRatingObjective(Range):
     """If enabled, choose the minimum park rating needed to beat the scenario."""

--- a/worlds/openrct2/__init__.py
+++ b/worlds/openrct2/__init__.py
@@ -518,11 +518,6 @@ class OpenRCT2World(World):
             add_rule(self.multiworld.get_region("Victory", self.player).entrances[0],
                      lambda state, selected_prereq=ride: state.has(selected_prereq, self.player))
 
-        if self.options.unique_rides_placement == "local":
-            self.options.local_items.value.update(self.unique_rides)
-        elif self.options.unique_rides_placement == "remote":
-            self.options.non_local_items.value.update(self.unique_rides)
-
 
     def generate_basic(self) -> None:
         # place "Victory" at the end of the unlock tree and set collection as win condition


### PR DESCRIPTION
Per discussion in world-dev: https://discord.com/channels/731205301247803413/1214608557077700720/1404100822400372808

The proposed alternative implementation for this feature would be to move the unique ride determination to `generate_early` instead of `set_rules`.  

Someone else in the OpenRCT2 post suggested duplicating the items in the apworld with a `Unique` prefix, and then they could be used in item groups, which enables them working in local_items and non_local_items without change.

As both of those are fairly invasive approaches, and beyond what I'm willing to work on, this PR is just removing the feature wholesale.

I've left the option available so it doesn't bork templates generated with it, but it's hidden so it won't show up in the future.  If you want me to remove the option I can do that as well, just LMK.