### PR TITLE
add option to limit required amount of unique rides in shop checks

### DIFF
--- a/worlds/openrct2/Options.py
+++ b/worlds/openrct2/Options.py
@@ -702,6 +702,15 @@ class ShopMaximumTotalCustomers(Range):
     range_end = 1000
     default = 400
 
+class ShopMaximumTotalRides(Range):
+    """If the shop determines you need a unique ride, this value will be the
+    highest number of that ride that it can ask for.
+    """
+    display_name = "Maximum Shop Total Rides Requirement"
+    range_start = 0
+    range_end = 7
+    default = 7
+
 class BalanceGuestCounts(DefaultOnToggle):
     """Attempts to balance the minimum guest requirements to the ride they're attached to. Low throughput rides
     like Spiral Slides will tend towards the minimum, while high throughput rides like roller coasters will 
@@ -859,6 +868,7 @@ openrct2_option_groups = [
         ShopMaximumLength,
         ShopMinimumTotalCustomers,
         ShopMaximumTotalCustomers,
+        ShopMaximumTotalRides,
         BalanceGuestCounts,
         SelectedVisibility,
         Awards,
@@ -895,6 +905,7 @@ class openRCT2Options(PerGameCommonOptions):
     shop_maximum_length: ShopMaximumLength
     shop_minimum_total_customers: ShopMinimumTotalCustomers
     shop_maximum_total_customers: ShopMaximumTotalCustomers
+    shop_maximum_total_rides: ShopMaximumTotalRides
     balance_guest_counts: BalanceGuestCounts
     awards: Awards
     exclude_safest_park: ExcludeSafestPark

--- a/worlds/openrct2/__init__.py
+++ b/worlds/openrct2/__init__.py
@@ -532,16 +532,16 @@ class OpenRCT2World(World):
                                 length = round(self.random.uniform(self.options.shop_minimum_length.value, 
                                 self.options.shop_maximum_length.value))
                             unlock["RidePrereq"] = \
-                                [self.random.randint(1, 3), chosen_prereq, excitement, intensity, nausea, length, total_customers]
+                                [self.random.randint(1, min(3, self.options.shop_maximum_total_rides.value)), chosen_prereq, excitement, intensity, nausea, length, total_customers]
                         elif (chosen_prereq in item_info["tracked_rides"]
                               and (self.options.scenario_length.value == 0 or #Sync Short
                               self.options.scenario_length.value == 1)):#Sync Long
-                            unlock["RidePrereq"] = [self.random.randint(1, 3), chosen_prereq, 0, 0, 0, 0, total_customers]
+                            unlock["RidePrereq"] = [self.random.randint(1, min(3, self.options.shop_maximum_total_rides.value)), chosen_prereq, 0, 0, 0, 0, total_customers]
                         else:
                             if number > 100:
-                                unlock["RidePrereq"] = [self.random.randint(1, 7), chosen_prereq, 0, 0, 0, 0, total_customers]
+                                unlock["RidePrereq"] = [self.random.randint(1, min(7, self.options.shop_maximum_total_rides.value)), chosen_prereq, 0, 0, 0, 0, total_customers]
                             else: #Even in async games, don't require too many rides too early
-                                unlock["RidePrereq"] = [self.random.randint(1, 3), chosen_prereq, 0, 0, 0, 0, total_customers]
+                                unlock["RidePrereq"] = [self.random.randint(1, min(3, self.options.shop_maximum_total_rides.value)), chosen_prereq, 0, 0, 0, 0, total_customers]
                     else:  # Prereq is not a specific ride
                         category = "ride"
                         category_selected = False


### PR DESCRIPTION
## What is this fixing or adding?
This adds a new option to the openrct2 apworld that allows the player to set the maximum quantity of a particular ride in the shop. This allows checks that require a specific unique ride to be limited to a quantity of the user's choice.

It's made to be non-intrusive to the current apworld code and works the same by default. An option is added to the yaml file that allows the limit to be set from 1 to 7. In the code that generates shop checks, the functions that calculate the number of unique rides was changed so that the maximum would be the minimum between the value that was originally there, and the player's configuration. In other words, if the default value is smaller than the player-provided value, it will be limited to the default value, and vice versa. This is to make sure that the original balancing is still in place if the player just goes with the default value.

## How was this tested?
I generated a world with it and played through a full game.
