### PR TITLE
Fix lambda capture in ride gating rules

### DIFF
--- a/worlds/openrct2/__init__.py
+++ b/worlds/openrct2/__init__.py
@@ -259,6 +259,7 @@ class OpenRCT2World(World):
 
         r.connect(s)
         s.connect(self.multiworld.get_region("OpenRCT2_Level_0", self.player))
+        total_rides = sum(1 for item in self.item_table if item in item_info["Rides"])
         count = 0
         while count < current_level:
             region = self.multiworld.get_region(f"OpenRCT2_Level_{count}", self.player)
@@ -289,7 +290,8 @@ class OpenRCT2World(World):
                     add_rule(region_entrance, lambda state: state.has("Cash Machine", self.player, 1))
                 if "First Aid" in self.item_table:
                     add_rule(region_entrance, lambda state: state.has("First Aid", self.player, 1))
-            add_rule(region_entrance, lambda state: state.has_group("Rides", self.player, num_rides))
+            num_rides = min(num_rides, total_rides)
+            add_rule(region_entrance, lambda state, num_rides=num_rides: state.has_group("Rides", self.player, num_rides))
             count += 1
         #print("Here's the total level of regions: " + str(current_level))
         final_region = self.multiworld.get_region("OpenRCT2_Level_" + str(current_level), self.player)


### PR DESCRIPTION
The lambda in the level progression loop captured num_rides by reference, so all regions ended up using the value from the last iteration (which was more than likely 0 as everything past level 5 had `num_rides` set to 0, effectively making this dead code. Each level now correctly captures its own threshold.

Also cap num_rides to the actual number of rides in the pool, since the hardcoded thresholds can exceed what a scenario provides which would end up with Victory not being accessible.

100% failure before using this fuzzer hook: https://github.com/Mysteryem/Archipelago-fuzzer/blob/8b80a433fe57570b644fe9d245b1eb6a61be3d89/hooks/detect_rule_variable_capture_issues.py

After the fixes, 0 failure on 5k fuzzing attempts with the hook, 0 failure on 15k normal gens.
